### PR TITLE
Add delay to display chall information

### DIFF
--- a/backend/instancer/api/challenge.py
+++ b/backend/instancer/api/challenge.py
@@ -15,26 +15,18 @@ def deployment_status(chall: Challenge) -> dict[str, Any] | None:
     if status is None:
         return None
     start_delay = status.expiration - 3570
-    if start_delay < int(time()):
-        return {
-            "expiration": status.expiration,
-            "start_delay": start_delay,
-            "port_mappings": {
-                f"{container}:{internal}": external
-                for (
-                    container,
-                    internal,
-                ), external in status.port_mappings.items()
-            },
-            "host": config.challenge_host,
-        }
-    else:
-        return {
-            "expiration": status.expiration,
-            "start_delay": start_delay,
-            "port_mappings": None,
-            "host": None,
-        }
+    return {
+        "expiration": status.expiration,
+        "start_delay": start_delay,
+        "port_mappings": {
+            f"{container}:{internal}": external
+            for (
+                container,
+                internal,
+            ), external in status.port_mappings.items()
+        },
+        "host": config.challenge_host,
+    }
 
 
 def challenge_info(chall: Challenge, tags: list[ChallengeTag]) -> dict[str, Any]:

--- a/backend/instancer/api/challenge.py
+++ b/backend/instancer/api/challenge.py
@@ -16,6 +16,7 @@ def deployment_status(chall: Challenge) -> dict[str, Any] | None:
         if status is None
         else {
             "expiration": status.expiration,
+            "start_delay": status.expiration - 60,
             "port_mappings": {
                 f"{container}:{internal}": external
                 for (

--- a/backend/instancer/api/challenge.py
+++ b/backend/instancer/api/challenge.py
@@ -12,10 +12,10 @@ def deployment_status(chall: Challenge) -> dict[str, Any] | None:
     """Return a dict with the challenge deployment status or None if the challenge is not deployed."""
 
     status = chall.deployment_status()
-    start_delay = 3570
     if status is None:
         return None
-    elif start_delay < int(time()):
+    start_delay = status.expiration - 3570
+    if start_delay < int(time()):
         return {
             "expiration": status.expiration,
             "start_delay": start_delay,

--- a/backend/instancer/api/challenge.py
+++ b/backend/instancer/api/challenge.py
@@ -1,3 +1,4 @@
+from time import time
 from typing import Any
 
 from flask import Blueprint, g
@@ -11,12 +12,12 @@ def deployment_status(chall: Challenge) -> dict[str, Any] | None:
     """Return a dict with the challenge deployment status or None if the challenge is not deployed."""
 
     status = chall.deployment_status()
-    return (
-        None
-        if status is None
-        else {
+    if status is None:
+        return None
+    elif (status.expiration - 3540) < int(time()):
+        return {
             "expiration": status.expiration,
-            "start_delay": status.expiration - 60,
+            "start_delay": status.expiration - 3540,
             "port_mappings": {
                 f"{container}:{internal}": external
                 for (
@@ -26,7 +27,13 @@ def deployment_status(chall: Challenge) -> dict[str, Any] | None:
             },
             "host": config.challenge_host,
         }
-    )
+    else:
+        return {
+            "expiration": status.expiration,
+            "start_delay": status.expiration - 3540,
+            "port_mappings": None,
+            "host": None,
+        }
 
 
 def challenge_info(chall: Challenge, tags: list[ChallengeTag]) -> dict[str, Any]:

--- a/backend/instancer/api/challenge.py
+++ b/backend/instancer/api/challenge.py
@@ -12,12 +12,13 @@ def deployment_status(chall: Challenge) -> dict[str, Any] | None:
     """Return a dict with the challenge deployment status or None if the challenge is not deployed."""
 
     status = chall.deployment_status()
+    start_delay = 3570
     if status is None:
         return None
-    elif (status.expiration - 3540) < int(time()):
+    elif start_delay < int(time()):
         return {
             "expiration": status.expiration,
-            "start_delay": status.expiration - 3540,
+            "start_delay": start_delay,
             "port_mappings": {
                 f"{container}:{internal}": external
                 for (
@@ -30,7 +31,7 @@ def deployment_status(chall: Challenge) -> dict[str, Any] | None:
     else:
         return {
             "expiration": status.expiration,
-            "start_delay": status.expiration - 3540,
+            "start_delay": start_delay,
             "port_mappings": None,
             "host": None,
         }

--- a/frontend/src/chall.tsx
+++ b/frontend/src/chall.tsx
@@ -261,12 +261,17 @@ const Chall = () => {
                             <Stop className="buttonsvg r" />
                         </button>
                     )}
-                    {Date.now() / 1000 > deployment.start_delay &&
+                    {Date.now() / 1000 > deployment.start_delay ? (
                         ports.map((p: string | JSX.Element) => (
                             <div className="IP-port-box" key={p as string}>
                                 {p}
                             </div>
-                        ))}
+                        ))
+                    ) : (
+                        <div className="IP-port-box" key="loading">
+                            loading challenge information...
+                        </div>
+                    )}
                 </div>
             );
         } else {

--- a/frontend/src/chall.tsx
+++ b/frontend/src/chall.tsx
@@ -269,7 +269,7 @@ const Chall = () => {
                         ))
                     ) : (
                         <div className="IP-port-box" key="loading">
-                            loading challenge information...
+                            challenge is booting up
                         </div>
                     )}
                 </div>

--- a/frontend/src/chall.tsx
+++ b/frontend/src/chall.tsx
@@ -185,6 +185,7 @@ const Chall = () => {
 
     /* hosts and ports */
     const [ports, setPorts] = useState<(string | JSX.Element)[]>([]);
+
     useEffect(() => {
         if (deployed && deployment) {
             const outPorts: (string | JSX.Element)[] = [];
@@ -242,7 +243,7 @@ const Chall = () => {
             </>
         );
 
-        if (deployed) {
+        if (deployed && deployment) {
             buttons = (
                 <div className="deployment-info">
                     {chall.is_shared ? (
@@ -260,11 +261,12 @@ const Chall = () => {
                             <Stop className="buttonsvg r" />
                         </button>
                     )}
-                    {ports.map((p: string | JSX.Element) => (
-                        <div className="IP-port-box" key={p as string}>
-                            {p}
-                        </div>
-                    ))}
+                    {Date.now() / 1000 > deployment.start_delay &&
+                        ports.map((p: string | JSX.Element) => (
+                            <div className="IP-port-box" key={p as string}>
+                                {p}
+                            </div>
+                        ))}
                 </div>
             );
         } else {

--- a/frontend/src/util/types.ts
+++ b/frontend/src/util/types.ts
@@ -40,6 +40,7 @@ export type TagType = {
 export type DeploymentType = {
     expiration: number;
     host: string;
+    start_delay: number;
     port_mappings: Record<string, string | number>;
 };
 


### PR DESCRIPTION
Does #11 
Add a delay to show challenge host/port information (currently it is hard coded at ~30 seconds, but this can change)
Would like this to be tested a bit