### PR TITLE
Patch/captcha

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
           - "psycopg[pool] ~= 3.1.9"
           - "pycryptodome ~= 3.18.0"
           - "python-dotenv ~= 1.0.0"
+          - "types-requests ~= 2.31.0"
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/backend/app.py
+++ b/backend/app.py
@@ -27,7 +27,11 @@ app.register_blueprint(api.blueprint)
 def react(chall_id: str = "") -> ResponseReturnValue:
     return render_template(
         "index.html",
-        client_conf={"rctf_mode": config.rctf_mode, "rctf_url": config.rctf_url},
+        client_conf={
+            "rctf_mode": config.rctf_mode,
+            "rctf_url": config.rctf_url,
+            "recaptcha_site_key": config.recaptcha_site_key,
+        },
     )
 
 

--- a/backend/instancer/api/authentication.py
+++ b/backend/instancer/api/authentication.py
@@ -2,6 +2,8 @@ import json
 import secrets
 from typing import Any, cast
 
+import requests
+
 from instancer.config import config, rclient
 
 
@@ -37,3 +39,13 @@ def del_session(token: str) -> bool:
     """
 
     return rclient.delete(f"session:{token}") == 1
+
+
+def verify_captcha_token(token: str) -> bool:
+    """Verifies captcha token via Google re-captcha
+
+    Returns True if verified and False otherwise
+    """
+    print(token)
+
+    return True

--- a/backend/instancer/api/authentication.py
+++ b/backend/instancer/api/authentication.py
@@ -41,11 +41,20 @@ def del_session(token: str) -> bool:
     return rclient.delete(f"session:{token}") == 1
 
 
-def verify_captcha_token(token: str) -> bool:
+def verify_captcha_token(token: str | None) -> bool:
     """Verifies captcha token via Google re-captcha
 
     Returns True if verified and False otherwise
     """
-    print(token)
+    if token == None:
+        return False
 
-    return True
+    try:
+        res = requests.post(
+            f"https://www.google.com/recaptcha/api/siteverify?secret={config.recaptcha_secret}&response={token}"
+        ).json()
+
+        success: bool = res["success"]
+        return success
+    except (KeyError, requests.JSONDecodeError):
+        return False

--- a/backend/instancer/api/challenge.py
+++ b/backend/instancer/api/challenge.py
@@ -80,7 +80,7 @@ def challenge_deploy() -> ResponseReturnValue:
 
     if not verify_captcha_token(body["captcha_token"]):
         return {
-            "status": "invalid_token",
+            "status": "invalid_captcha_token",
             "msg": "Invalid CAPTCHA token",
         }, 498
 

--- a/backend/instancer/config.py
+++ b/backend/instancer/config.py
@@ -66,6 +66,8 @@ class PartialConfig:
     challenge_host: str = "localhost"
     rctf_mode: bool = False
     rctf_url: str | None = None
+    recaptcha_site_key: str | None = None
+    recaptcha_secret: str | None = None
     session_length: int = 24 * 3600
 
 
@@ -148,6 +150,8 @@ def apply_config(c: dict[str, Any]) -> None:
                 "rctf_mode": {"type": "boolean"},
                 "rctf_url": {"type": "string"},
                 "session_length": {"type": "integer"},
+                "recaptcha_site_key": {"type": "string"},
+                "recaptcha_secret": {"type": "string"},
             },
         },
     )
@@ -170,6 +174,8 @@ def apply_config(c: dict[str, Any]) -> None:
     apply_dict(c, "rctf_mode", "rctf_mode")
     apply_dict(c, "session_length", "session_length")
     apply_dict(c, "rctf_url", "rctf_url")
+    apply_dict(c, "recaptcha_site_key", "recaptcha_site_key")
+    apply_dict(c, "recaptcha_secret", "recaptcha_secret")
 
 
 try:
@@ -196,6 +202,8 @@ apply_env("INSTANCER_CHALLENGE_HOST", "challenge_host")
 apply_env("INSTANCER_RCTF_MODE", "rctf_mode", func=parse_bool)
 apply_env("INSTANCER_SESSION_LENGTH", "session_length", func=int)
 apply_env("INSTANCER_RCTF_URL", "rctf_url")
+apply_env("INSTANCER_RECAPTCHA_SITE_KEY", "recaptcha_site_key")
+apply_env("INSTANCER_RECAPTCHA_SECRET", "recaptcha_secret")
 
 config = Config(partial_config)
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,4 +1,5 @@
 types-redis ~= 4.5.1
 types-PyYAML ~= 6.0
 types-jsonschema ~= 4.17
+types-requests ~= 2.31.0
 psycopg[pool] ~= 3.1.9

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ kubernetes ~= 26.1.0
 jsonschema ~= 4.17.3
 psycopg ~= 3.1.9
 pycryptodome ~= 3.18.0
+requests ~= 2.31.0

--- a/config.example.yml
+++ b/config.example.yml
@@ -18,3 +18,5 @@ challenge_host: instancer.example.com
 rctf_mode: true
 rctf_url: "https://rctf.example.com"
 session_length: 86400
+recaptcha_site_key: "recaptchasitekeyobtainedfromgoogle"
+recaptcha_secret: "recaptchasecretobtainedfromgoogle"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,10 +9,12 @@
             "version": "1.0.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
+                "@types/react-google-recaptcha": "^2.1.6",
                 "axios": "^1.4.0",
                 "http-proxy-middleware": "^2.0.6",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-google-recaptcha": "^3.1.0",
                 "react-router-dom": "^6.11.1",
                 "use-local-storage-state": "^18.3.3",
                 "vite-plugin-svgr": "^3.2.0"
@@ -3219,14 +3221,12 @@
         "node_modules/@types/prop-types": {
             "version": "15.7.5",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-            "dev": true
+            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
         },
         "node_modules/@types/react": {
             "version": "18.2.21",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
             "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
-            "dev": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -3242,11 +3242,18 @@
                 "@types/react": "*"
             }
         },
+        "node_modules/@types/react-google-recaptcha": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@types/react-google-recaptcha/-/react-google-recaptcha-2.1.6.tgz",
+            "integrity": "sha512-U+dLY6lGoa9sDfArZAmAItk9MpOaNV7TJtRqEox74zkXL4Qx6FnakIeM9e3HQaWYwfBgoOa7SMhWBgpnyycdvQ==",
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
         "node_modules/@types/scheduler": {
             "version": "0.16.3",
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-            "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-            "dev": true
+            "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
         },
         "node_modules/@types/semver": {
             "version": "7.5.1",
@@ -4100,8 +4107,7 @@
         "node_modules/csstype": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-            "dev": true
+            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -5338,6 +5344,14 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
         "node_modules/http-proxy": {
             "version": "1.18.1",
             "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -6071,7 +6085,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6381,7 +6394,6 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -6433,6 +6445,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-async-script": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz",
+            "integrity": "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==",
+            "dependencies": {
+                "hoist-non-react-statics": "^3.3.0",
+                "prop-types": "^15.5.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.4.1"
+            }
+        },
         "node_modules/react-dom": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -6445,11 +6469,22 @@
                 "react": "^18.2.0"
             }
         },
+        "node_modules/react-google-recaptcha": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-3.1.0.tgz",
+            "integrity": "sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==",
+            "dependencies": {
+                "prop-types": "^15.5.0",
+                "react-async-script": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.4.1"
+            }
+        },
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-router": {
             "version": "6.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,10 +5,12 @@
     "private": true,
     "type": "module",
     "dependencies": {
+        "@types/react-google-recaptcha": "^2.1.6",
         "axios": "^1.4.0",
         "http-proxy-middleware": "^2.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-google-recaptcha": "^3.1.0",
         "react-router-dom": "^6.11.1",
         "use-local-storage-state": "^18.3.3",
         "vite-plugin-svgr": "^3.2.0"

--- a/frontend/src/chall.tsx
+++ b/frontend/src/chall.tsx
@@ -113,22 +113,22 @@ const Chall = () => {
         if (disableButton[index]) return;
         updateArr(index, disableButton, setDisableButton, true);
 
-        const captcha_token = captchaRef.current?.getValue();
-        captchaRef.current?.reset();
-
-        fetch("/api/challenge/" + ID + "/deploy", {
-            headers: {
-                Authorization: `Bearer ${accountToken as string}`,
-                "Content-Type": "application/json",
-            },
-            method: "POST",
-            body: JSON.stringify({
-                captcha_token: captcha_token,
-            }),
-        })
+        captchaRef.current
+            ?.executeAsync()
+            .then((captcha_token) =>
+                fetch("/api/challenge/" + ID + "/deploy", {
+                    headers: {
+                        Authorization: `Bearer ${accountToken as string}`,
+                        "Content-Type": "application/json",
+                    },
+                    method: "POST",
+                    body: JSON.stringify({
+                        captcha_token: captcha_token,
+                    }),
+                })
+            )
             .then((res) => res.json())
             .then((challengeDeployment: ChallengeDeploymentType) => {
-                console.log(challengeDeployment);
                 if (challengeDeployment.status === "ok") {
                     setDeployment(challengeDeployment.deployment);
                     setErrorMsg(null);
@@ -324,7 +324,7 @@ const Chall = () => {
             buttons = (
                 <>
                     <div className="deployment-info">
-                        <ReCaptcha sitekey={config.recaptcha_site_key || ""} ref={captchaRef} />
+                        <ReCaptcha sitekey={config.recaptcha_site_key || ""} ref={captchaRef} size="invisible" />
                         <button
                             className={"deploy OFF" + (isShaking[0] ? " shake-animation" : "")}
                             onClick={() => deployChallenge(0)}

--- a/frontend/src/chall.tsx
+++ b/frontend/src/chall.tsx
@@ -1,7 +1,7 @@
 import "./styles/index.css";
 import "./styles/chall.css";
 import {useState, useEffect} from "react";
-import {useParams, useSearchParams} from "react-router-dom";
+import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 import {ReactComponent as Timer} from "./images/timer.svg";
 import {ReactComponent as Stop} from "./images/stop.svg";
 
@@ -14,7 +14,8 @@ import {
 } from "./util/types.ts";
 import {prettyTime, getCategories, getTags, isDeployed} from "./util/utility.ts";
 import useAccountManagement from "./util/account";
-import {useNavigate} from "react-router-dom";
+
+import ReCaptcha from "react-google-recaptcha";
 
 function createLink(host: string) {
     let output: string = host;
@@ -42,6 +43,8 @@ const Chall = () => {
     const [deployment, setDeployment] = useState<DeploymentType | undefined>();
     const [deployed, setDeployed] = useState<boolean>(false);
     const [timer, setTimer] = useState<number>(-100);
+
+    const [captchaToken, setCaptchaToken] = useState<string | null>("");
 
     useEffect(() => {
         function loggedOutRedirect() {
@@ -109,8 +112,14 @@ const Chall = () => {
         if (disableButton[index]) return;
         updateArr(index, disableButton, setDisableButton, true);
         fetch("/api/challenge/" + ID + "/deploy", {
-            headers: {Authorization: `Bearer ${accountToken as string}`},
+            headers: {
+                Authorization: `Bearer ${accountToken as string}`,
+                "Content-Type": "application/json",
+            },
             method: "POST",
+            body: JSON.stringify({
+                captcha_token: captchaToken,
+            }),
         })
             .then((res) => res.json())
             .then((challengeDeployment: ChallengeDeploymentType) => {
@@ -306,6 +315,7 @@ const Chall = () => {
             buttons = (
                 <>
                     <div className="deployment-info">
+                        <ReCaptcha sitekey="" onChange={setCaptchaToken} />
                         <button
                             className={"deploy OFF" + (isShaking[0] ? " shake-animation" : "")}
                             onClick={() => deployChallenge(0)}

--- a/frontend/src/chall.tsx
+++ b/frontend/src/chall.tsx
@@ -128,6 +128,7 @@ const Chall = () => {
         })
             .then((res) => res.json())
             .then((challengeDeployment: ChallengeDeploymentType) => {
+                console.log(challengeDeployment);
                 if (challengeDeployment.status === "ok") {
                     setDeployment(challengeDeployment.deployment);
                     setErrorMsg(null);
@@ -136,6 +137,9 @@ const Chall = () => {
                     console.error("Deployment error");
                     updateArr(index, isShaking, setIsShaking, true);
                     setErrorMsg("Challenge temporarily unavailable. Please wait a few moments and try again.");
+                } else if (challengeDeployment.status === "invalid_captcha_token") {
+                    updateArr(index, isShaking, setIsShaking, true);
+                    setErrorMsg("CAPTCHA is required");
                 } else if (
                     challengeDeployment.status === "missing_authorization" ||
                     challengeDeployment.status === "invalid_token"

--- a/frontend/src/styles/chall.css
+++ b/frontend/src/styles/chall.css
@@ -11,10 +11,11 @@
 .deployment-info {
     margin-top: 5vh;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     flex-wrap: wrap;
     align-items: left;
-    justify-content: flex-start;
+    justify-content: space-between;
+    gap: 3vh;
 }
 
 .stat.ON {

--- a/frontend/src/styles/chall.css
+++ b/frontend/src/styles/chall.css
@@ -11,11 +11,10 @@
 .deployment-info {
     margin-top: 5vh;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     flex-wrap: wrap;
     align-items: left;
-    justify-content: space-between;
-    gap: 3vh;
+    justify-content: flex-start;
 }
 
 .stat.ON {

--- a/frontend/src/util/config.ts
+++ b/frontend/src/util/config.ts
@@ -1,6 +1,7 @@
 export type ClientConfigType = {
     rctf_mode: boolean;
     rctf_url: string | null;
+    recaptcha_site_key: string | null;
 };
 
 const config = JSON.parse(


### PR DESCRIPTION
Implement CAPTCHA for challenge deployment endpoint.

Resolves #18 

## Implementation Details
The implementation works as follows
1. User completes re-captcha checkbox
2. Token representing this completion is sent in deployment request
3. This token is assessed by the Google API
4. If invalid, then return 498 (Invalid token) error to client
5. Display error appropriately

## Notes

- introduces two new fields to `config.yml`: 
  - `recaptcha_site_key`
  - `recaptcha_secret`
  - These can be found under recaptcha on the Google Cloud Console (or you can just dm me)
  - Right now they are under the LACTF Project (let me know if we need to change this)
  - Note: the site key only works for sites hosted on domains under the allowed domains
    - if you want to test locally, you can temporarily disable domain verification (or create a new key without it if you're *secure*)

- My implementation utilizes recaptcha v2 (the checkbox) and googles legacy assessment API on the backend.
  - I chose these as they are by far the simplest
  - Upgrading to recaptcha v3 on the frontend is simple but I was under the impression that we wanted the checkbox. Let me know if we want v3 instead.
  - Regarding the backend, As far as I can tell we don't need any of the features introduced by the new assessment API (and the syntax is needlessly complex), so I would say the legacy API is our best bet unless someone has strong feelings against it.

